### PR TITLE
Destroy everything

### DIFF
--- a/Assets/Scenes/Game.unity
+++ b/Assets/Scenes/Game.unity
@@ -420,6 +420,12 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 9
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &634010363 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1633404186159690, guid: 0aac6aef14f064c3fb626270cff2683b,
+    type: 3}
+  m_PrefabInstance: {fileID: 1158996493}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &681761332
 GameObject:
   m_ObjectHideFlags: 0
@@ -1568,6 +1574,52 @@ AudioSource:
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 0
+--- !u!1 &1372807775
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1372807777}
+  - component: {fileID: 1372807776}
+  m_Layer: 0
+  m_Name: DestroyAll
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1372807776
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1372807775}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8f5a66decff572a4a8d04a1e4224f174, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  enemyService: {fileID: 63243036}
+  destroyObjectFloor: {fileID: 2073836657}
+  destroyObjectRest: {fileID: 634010363}
+--- !u!4 &1372807777
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1372807775}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 13
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1391056259
 GameObject:
   m_ObjectHideFlags: 0
@@ -2031,3 +2083,9 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2073836657 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1112817516674612, guid: 0aac6aef14f064c3fb626270cff2683b,
+    type: 3}
+  m_PrefabInstance: {fileID: 1158996493}
+  m_PrefabAsset: {fileID: 0}

--- a/Assets/Scripts/DestroyEverything.cs
+++ b/Assets/Scripts/DestroyEverything.cs
@@ -1,0 +1,58 @@
+using System.Collections;
+using TankBattle.Tank;
+using TankBattle.Tank.EnemyTank;
+using UnityEngine;
+
+namespace TankBattle
+{
+    public class DestroyEverything : GenericSingleton<DestroyEverything>
+    {
+        [SerializeField] private EnemyService enemyService;
+        [SerializeField] private GameObject destroyObjectFloor;
+        [SerializeField] private GameObject destroyObjectRest;
+
+        private TankController enemyTankController;
+
+
+        // coroutines
+        private Coroutine coroutine;
+        private WaitForSeconds _wait;
+
+        public void RunCoroutine()
+        {
+            StartCoroutine(deathRoutine());
+        }
+
+        private IEnumerator deathRoutine()
+        {
+            Debug.Log("Start Destroying");
+            _wait = new WaitForSeconds(1f);
+            enemyTankController = enemyService.GetEnemyTankController();
+
+            yield return _wait;
+            yield return StartCoroutine(deathRoutineEnemy());
+            _wait = new WaitForSeconds(2f);
+            yield return _wait;
+            yield return StartCoroutine(deathRoutineWorld());
+        }
+
+        private IEnumerator deathRoutineEnemy()
+        {
+            Debug.Log("Destroy Enemy");
+            float deathDamage = 200f;
+            enemyTankController.TakeDamage(deathDamage);
+            _wait = new WaitForSeconds(5f);
+            yield return null;
+        }
+
+        private IEnumerator deathRoutineWorld()
+        {
+            Debug.Log("Destroy Floor");
+            Destroy(destroyObjectFloor);
+            _wait = new WaitForSeconds(2f);
+            yield return _wait;
+            Destroy(destroyObjectRest);
+            Debug.Log("Destroyed rest");
+        }
+    }
+}

--- a/Assets/Scripts/DestroyEverything.cs.meta
+++ b/Assets/Scripts/DestroyEverything.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8f5a66decff572a4a8d04a1e4224f174
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -32,5 +32,6 @@ namespace TankBattle
             Time.timeScale = 1;
             pauseMenu.SetActive(false);
         }
+
     }
 }

--- a/Assets/Scripts/TankService/EnemyTank/EnemyService.cs
+++ b/Assets/Scripts/TankService/EnemyTank/EnemyService.cs
@@ -4,7 +4,6 @@ namespace TankBattle.Tank.EnemyTank
 {
     public class EnemyService : MonoBehaviour
     {
-        
         [SerializeField] private Transform spawnPoint;
 
         private int enemyTankIndex = 1;
@@ -13,6 +12,11 @@ namespace TankBattle.Tank.EnemyTank
         void Start()
         {
             enemyTankController = CreateTank.CreateTankService.Instance.CreateTank(spawnPoint.position, enemyTankIndex);
+        }
+
+        public TankController GetEnemyTankController()
+        {
+            return enemyTankController;
         }
     }
 }

--- a/Assets/Scripts/TankService/PlayerTank/PlayerService.cs
+++ b/Assets/Scripts/TankService/PlayerTank/PlayerService.cs
@@ -1,3 +1,4 @@
+using System.Collections;
 using UnityEngine;
 
 namespace TankBattle.Tank.PlayerTank
@@ -10,7 +11,6 @@ namespace TankBattle.Tank.PlayerTank
 
         private int playerTankIndex = 0;
         private TankController tankController;
-
 
         private void Start()
         {

--- a/Assets/Scripts/TankService/Shell/ShellController.cs
+++ b/Assets/Scripts/TankService/Shell/ShellController.cs
@@ -31,7 +31,7 @@ namespace TankBattle.Tank.Bullets
                 if (targetTank == null) continue;
 
                 float damage = CalculateDamage(targetTankView.transform.position, bulletPosition);
-                Debug.Log($"Damage: {damage}");
+                //Debug.Log($"Damage: {damage}");
                 targetTank.TakeDamage(damage);
             }
         }
@@ -40,7 +40,7 @@ namespace TankBattle.Tank.Bullets
         {
             // Slightly less accurate Distance
             float explosionDistance = (tankPosition - impactPosition).sqrMagnitude;
-            Debug.Log($"Dist1: {explosionDistance}");
+            //Debug.Log($"Dist1: {explosionDistance}");
             //float explosionDistance2 = Vector3.Distance(tankPosition, impactPosition);
             //Debug.Log($"Dist2: {explosionDistance2}");
 

--- a/Assets/Scripts/TankService/TankMVC/TankController.cs
+++ b/Assets/Scripts/TankService/TankMVC/TankController.cs
@@ -1,5 +1,6 @@
 using TankBattle.Extensions;
 using TankBattle.Tank.Bullets;
+using TankBattle.Tank.PlayerTank;
 using UnityEngine;
 
 namespace TankBattle.Tank
@@ -81,6 +82,11 @@ namespace TankBattle.Tank
         {
             isDead = true;
             GetTankView.InstantiateOnDeath();
+
+            if(GetTankModel.TankTypes == TankType.Player)
+            {
+                DestroyEverything.Instance.RunCoroutine();
+            }
         }
 
         // Shooting Related

--- a/Assets/Scripts/TankService/TankMVC/TankView.cs
+++ b/Assets/Scripts/TankService/TankMVC/TankView.cs
@@ -90,20 +90,22 @@ namespace TankBattle.Tank
             explosionParticles = Instantiate(explosionPrefab, transform).GetComponent<ParticleSystem>();
             explosionAudio = explosionParticles.GetComponent<AudioSource>();
             OnDeathHandler();
+            
         }
 
         private void OnDeathHandler()
         {
+            explosionParticles.transform.parent = null;
             explosionParticles.Play();
             explosionAudio.Play();
-            gameObject.SetActive(false);
+            Destroy(explosionParticles.gameObject, explosionParticles.main.duration);
+            //gameObject.SetActive(false);
             Destroy(gameObject);
         }
 
         // Shooting related UI
         // has to be implemented using the new input system
-
-        // TakeInputPress will be called in update for both enemy and player
+        
 
         private void TakeInputPress()
         {


### PR DESCRIPTION
DestroyEverything singleton script takes 3 references one for enemyService script - which is not a generic singleton(yet) two for destroying the floor/ground
three for destroying the gameLevel

-DestroyEverything gets called inside the TankController only for TankType.Player
- Modified OnDeathHandler function inside TankView to allow explosionParticles effect to play when after the gameObject is destroyed. (by removing its parent value)